### PR TITLE
Fix invalid calls to format_api_error

### DIFF
--- a/lib/smartling/api.rb
+++ b/lib/smartling/api.rb
@@ -48,7 +48,7 @@ module Smartling
 
     def check_response(res)
       return if res.code == 200
-      format_api_error(res.body) 
+      format_api_error(res) 
       raise 'API_ERROR' 
     end
 
@@ -60,7 +60,7 @@ module Smartling
         if body['code'] == 'SUCCESS'
           return body['data']
         else
-          format_api_error(res.body) 
+          format_api_error(res) 
           raise 'API_ERROR' 
         end
       end


### PR DESCRIPTION
Calls like this cause a crash because `format_api_error` expects a `res`:

```diff
- format_api_error(res.body) 
+ format_api_error(res) 
```

Context:
```ruby
def format_api_error(res)
  begin
    body = MultiJson.decode(res.body)
  rescue
  end
  ...
end
```